### PR TITLE
Add option to overide the class and method name for custom delayed jobs

### DIFF
--- a/lib/appsignal/integrations/delayed_job.rb
+++ b/lib/appsignal/integrations/delayed_job.rb
@@ -11,7 +11,13 @@ if defined?(::Delayed::Plugin)
         end
 
         def self.invoke_with_instrumentation(job, block)
-          class_name, method_name = job.name.split('#')
+          class_and_method_name = if job.payload_object.respond_to?(:appsignal_name)
+            job.payload_object.appsignal_name
+          else
+            job.name
+          end
+          class_name, method_name = class_and_method_name.split('#')
+
           Appsignal.monitor_transaction(
             'perform_job.delayed_job',
             :class => class_name,


### PR DESCRIPTION
Example:

```
class StructJobWithName < Struct.new(:id)

  def perform
    true
  end

  def display_name
    "StructJobWithName-#{id}"
  end

  def appsignal_name
    "StructJobWithName#perform"
  end

end
```

AppSignal requires a proper formatted job name that consists of the class and method of a job. 
When using `display_name`, Delayed Job will return this as the class/method name of the job. 
This can cause issues on AppSignal, as a new incident is created for each individual job name, resulting in hundreds of different incidents. 

To counter this, use `appsignal_name` to return the original class/method name, so all incidents will be grouped by that name. 