### PR TITLE
Set the app environment using the APPSIGNAL_APP_ENV env var

### DIFF
--- a/lib/appsignal/integrations/rails.rb
+++ b/lib/appsignal/integrations/rails.rb
@@ -22,7 +22,7 @@ if defined?(::Rails)
           # Load config
           Appsignal.config = Appsignal::Config.new(
             Rails.root,
-            Rails.env,
+            ENV.fetch('APPSIGNAL_APP_ENV', Rails.env),
             :name => Rails.application.class.parent_name
           )
 


### PR DESCRIPTION
My current context for this patch:

I have an app running in three environments (qa, stage, production), but I keep only the production file environment, it means that each one runs as "production" (RAILS_ENV=production). The solution I found to use AppSignal is to have different app names for each environment (`my-app-qa`, `my-app-stage`, `my-app-prod`) using the `APPSIGNAL_APP_NAME`.

With this patch, we'll be able to define just one name and differentiate the environment for each app instance (basically is exactly what the `appsignal.yml` does when the app is running in different environments).

I've tried to add a test for this change, but I couldn't. I'd appreciate any help.