### PR TITLE
Notifying via server

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,26 +1,23 @@
 namespace :appsignal do
   task :deploy do
-    env = fetch(:rails_env, fetch(:rack_env, 'production'))
-    user = ENV['USER'] || ENV['USERNAME']
-    revision = fetch(:appsignal_revision, fetch(:current_revision))
-    logger = fetch(:logger, Logger.new($stdout))
+    params = {
+      revision: fetch(:appsignal_revision, fetch(:current_revision)),
+      user: ENV['USER'] || ENV['USERNAME'],
+      environment: fetch(:rails_env, fetch(:rack_env, 'production'))
+    }
 
-    appsignal_config = Appsignal::Config.new(
-      ENV['PWD'],
-      env,
-      fetch(:appsignal_config, {}),
-      logger
-    )
-
-    if appsignal_config && appsignal_config.active?
-      marker_data = {
-        :revision => revision,
-        :user => user
-      }
-
-      marker = Appsignal::Marker.new(marker_data, appsignal_config, logger)
-      marker.transmit
+    on roles fetch(:appsignal_roles) do
+      within release_path do
+        execute *fetch(:appsignal_bin), 'notify_of_deploy', params.map { |k,v| "--#{k}=#{v}" }.join(' ')
+      end
     end
+  end
+end
+
+namespace :load do
+  task :defaults do
+    set :appsignal_roles, :all
+    set :appsignal_bin, [:appsignal]
   end
 end
 


### PR DESCRIPTION
This change is a result of me trying to understand why none of my apps showed any deploys on AppSignal. It turns out, the current capistrano task notifies the AppSignal service via the same machine that is issuing the deploy.

This is a problem for me (and I would assume for more people) because it requires me to setup the appsignal deploy key both locally as well as in our CI server.
Since we already have that same key set up in production, I see no point in duplicating that

Plus, requiring the key to exist locally (or in the CI) can lead to other errors. For example, one of my coworkers might not have it, which will make his deploy go unnoticed to AppSignal


This proposal makes the deploy notification occur on the server instead, by issuing `appsignal notify_of_deploy` with the appropriate parameters
This way, the server will handle the notification, regardless of who issued the deploy, and there's no need to store the push key outside the server itself

I also added some configurables values, so that other developers can customize the command required to access the appsignal binary. For example, in my case, I had to add `set :appsignal_bin, %i(foreman run appsignal)` since I'm using foreman to load the environment variables in production