### PR TITLE
Custom instrumentation methods opt-in for Object

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -24,6 +24,7 @@ module Appsignal
 
     def load_instrumentations
       require 'appsignal/instrumentations/net_http' if config[:instrument_net_http]
+      require 'appsignal/instrumentations/object' if config[:instrumentation_methods]
     end
 
     def extensions

--- a/lib/appsignal/instrumentations/object.rb
+++ b/lib/appsignal/instrumentations/object.rb
@@ -1,0 +1,35 @@
+class Object
+  def self.measure(method, category_name=nil)
+    alias_method "#{method}_unmeasured", method
+    define_method method do |*args|
+      cat_name = if category_name.respond_to?(:call)
+                   self.instance_exec args, &category_name
+                 elsif category_name && category_name.respond_to?(:to_s)
+                   category_name.to_s
+                 else
+                   first = args.first
+                   if first.respond_to?(:to_s)
+                     first.to_s
+                   else
+                     nil
+                   end
+                 end
+
+      ActiveSupport::Notifications.instrument(
+        "#{self.class.name}.#{method.to_s}",
+        :name => cat_name
+      ) do
+        send "#{method}_unmeasured", *args
+      end
+    end
+  end
+
+  def measure(name, cat = "")
+    names = [self.class.name, __method__.to_s.gsub(/:/,''), name.downcase.gsub(/ /, '_')]
+    result = nil
+    ActiveSupport::Notifications.instrument(names.join('.'), name: cat) do
+      result = yield
+    end
+    result
+  end
+end

--- a/spec/lib/appsignal/instrumentations/object_spec.rb
+++ b/spec/lib/appsignal/instrumentations/object_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require File.expand_path('lib/appsignal/instrumentations/object')
+
+describe "Object custom instrumentation methods" do
+  let(:events) { [] }
+  before do
+    ActiveSupport::Notifications.subscribe(/^[^!]/) do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+
+  it "should instrument my method" do
+    result = TestClass.new.my_method
+    result.should == "peanuts"
+
+    event = events.last
+    event.name.should == 'TestClass.my_method'
+  end
+
+  it "should instrument within a method" do
+    result = TestClass.new.my_other_method
+    result.should == "peanuts"
+
+    event = events.last
+    event.name.should == 'TestClass.measure.bananas'
+  end
+
+  class TestClass
+    def my_method
+      "peanuts"
+    end
+    measure :my_method
+
+    def my_other_method
+      measure "bananas" do
+        "peanuts"
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've been meaning to PR this for some time.

It allows measuring of arbitrary methods without much code overhead. We use it in production a lot.

Not sure if monkey patching Object (even if opt-in) is such a good idea for everyone. Happy to make it a module instead if so desired.