### PR TITLE
Only track exceptions when Appsignal is active.

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -22,7 +22,7 @@ module Appsignal
       ensure
         # In production newer versions of Sinatra don't raise errors, but store
         # them in the sinatra.error env var.
-        Appsignal::Transaction.current.add_exception(env['sinatra.error']) if env['sinatra.error']
+        Appsignal::Transaction.current.add_exception(env['sinatra.error']) if env['sinatra.error'] && Appsignal.active?
       end
 
       def raw_payload(env)


### PR DESCRIPTION
Without this check, if you've forgotten to set appsignal environment
variables, the gem will throw an error because
`Appsignal::Transaction.current` is `nil`.