### PR TITLE
Add Rake monitoring

### DIFF
--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -1,0 +1,21 @@
+module Rake
+  class Task
+    alias_method :invoke_without_appsignal, :invoke
+
+    def invoke(*args)
+      transaction = Appsignal::Transaction.create(SecureRandom.uuid, ENV)
+      transaction.set_kind('background_job')
+      transaction.set_action(name)
+
+      invoke_without_appsignal(*args)
+    rescue => exception
+      unless Appsignal.is_ignored_exception?(exception)
+        transaction.add_exception(exception)
+      end
+      raise exception
+    ensure
+      transaction.complete!
+      Appsignal.agent.send_queue if Appsignal.active?
+    end
+  end
+end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -68,6 +68,14 @@ module Appsignal
       @paused = false
     end
 
+    def set_kind(kind)
+      @kind = kind
+    end
+
+    def set_action(action)
+      @action = action
+    end
+
     def set_process_action_event(event)
       return unless event && event.payload
       @process_action_event = event.dup
@@ -95,7 +103,7 @@ module Appsignal
     def add_exception(ex=nil)
       return unless ex
       Appsignal.logger.debug("Adding #{ex.class.name} to transaction: #{request_id}")
-      @time = Time.now.utc.to_f
+      @time      = Time.now.utc.to_f
       @exception = {
         :exception  => ex.class.name,
         :message    => ex.message,

--- a/lib/appsignal/transaction/formatter.rb
+++ b/lib/appsignal/transaction/formatter.rb
@@ -26,6 +26,7 @@ module Appsignal
           :log_entry => {
             :path => fullpath,
             :kind => kind,
+            :action => action,
             :time => time,
             :environment => sanitized_environment,
             :session_data => sanitized_session_data,

--- a/spec/lib/appsignal/integrations/rake_spec.rb
+++ b/spec/lib/appsignal/integrations/rake_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'rake'
+describe "Rack integration" do
+  let(:file) { File.expand_path('lib/appsignal/integrations/rake.rb') }
+  let(:app)  { double(:current_scope => nil) }
+  let(:task) { Rake::Task.new('task', app) }
+  before do
+    load file
+  end
+
+  describe "#invoke" do
+    before do
+      task.stub(
+        :name                     => 'task:name',
+        :invoke_without_appsignal => true
+      )
+    end
+
+    it "should create a transaction" do
+      expect( Appsignal::Transaction ).to receive(:create)
+    end
+
+    context "with transaction" do
+      let!(:transaction) { Appsignal::Transaction.new('123', {}) }
+      let!(:agent)       { double('Agent', :send_queue => true) }
+      before do
+        Appsignal::Transaction.stub(:create => transaction)
+        Appsignal.stub(:agent => agent, :active? => true)
+      end
+
+      it "should set the kind" do
+        expect( transaction ).to receive(:set_kind).with('background_job')
+      end
+
+      it "should set the action" do
+        expect( transaction ).to receive(:set_action).with('task:name')
+      end
+
+      it "should call the original task" do
+        expect( task ).to receive(:invoke_without_appsignal).with('foo')
+      end
+
+      it "should complete the transaction" do
+        expect( transaction ).to receive(:complete!)
+      end
+
+      it "should send the queue" do
+        expect( Appsignal.agent ).to receive(:send_queue)
+      end
+
+      context "when Appsignal is not active" do
+        before { Appsignal.stub(:active? => false) }
+
+        it "should not send the queue" do
+          expect( Appsignal.agent ).to_not receive(:send_queue)
+        end
+      end
+
+      context "with an exception" do
+        let(:exception) { VerySpecificError.new }
+
+        before do
+          task.stub(:invoke_without_appsignal).and_raise(exception)
+          Appsignal.stub(:is_ignored_exception? => false )
+        end
+
+        it "should add the exception to the transaction" do
+          expect( transaction ).to receive(:add_exception).with(exception)
+        end
+
+        context "when ignored" do
+          before { Appsignal.stub(:is_ignored_exception? => true ) }
+
+          it "should NOT add the exception to the transaction" do
+            expect( transaction ).to_not receive(:add_exception)
+          end
+        end
+      end
+    end
+
+    after { task.invoke('foo') rescue VerySpecificError }
+  end
+end

--- a/spec/lib/appsignal/transaction/formatter_spec.rb
+++ b/spec/lib/appsignal/transaction/formatter_spec.rb
@@ -56,6 +56,30 @@ describe Appsignal::Transaction::Formatter do
       end
     end
 
+    context "with a background request without payload" do
+      let(:transaction) do
+        Appsignal::Transaction.new('123', {}).tap do |transaction|
+          transaction.set_kind('web')
+          transaction.set_action('foo#bar')
+        end
+      end
+
+      it "should get the kind and action from the transaction" do
+        subject.to_hash.should == {
+          :request_id => '123',
+          :log_entry  => {
+            :path         => '/foo',
+            :kind         => 'web',
+            :action       => 'foo#bar',
+            :time         => nil,
+            :environment  => {},
+            :session_data => {},
+            :revision     => nil},
+          :failed => false
+        }
+      end
+    end
+
     context "with an exception request" do
       let(:transaction) { transaction_with_exception }
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -189,6 +189,22 @@ describe Appsignal::Transaction do
       end
     end
 
+    describe "#set_kind" do
+      it "should set the kind" do
+        expect{
+          transaction.set_kind('web')
+        }.to change(transaction, :kind).from(nil).to('web')
+      end
+    end
+
+    describe "#set_action" do
+      it "should set the action" do
+        expect{
+          transaction.set_action('foo#bar')
+        }.to change(transaction, :action).from(nil).to('foo#bar')
+      end
+    end
+
     context "using exceptions" do
       let(:exception) do
         double(


### PR DESCRIPTION
We need to decide wether we want to monitor a rake job (with possibly tons of instrumentation and events), or if we only want to catch errors.

I'm not sure what the value in performance monitoring in rake tasks is, since it's already a background task, mostly used for long running (slow) jobs. 

Thoughts? 