### PR TITLE
Fix an issue with Padrino integrations

### DIFF
--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -37,7 +37,7 @@ module Padrino::Routing::InstanceMethods
         rescue => e
           Appsignal.add_exception(e); raise e
         ensure
-          payload[:action] = "#{settings.name}:#{request.controller}##{request.action}"
+          payload[:action] = "#{settings.name}:#{request.controller}##{request.fullpath}"
         end
       end
     end


### PR DESCRIPTION
When testing the Padrino Integration using Padrino 0.10.7 (which depends on Sinatra 1.3.1), there's no action method available to the Sinatra::Request object. This pull request switches to use the `Request`'s `fullpath` method, that will return the route's path. This is the cleanest output I could find.

There doesn't seem to be anything inside the available Padrino or Sinatra request objects (with no mention of "action" inside the [sinatra request code](https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb)), at least in our environment, to report the action, which I suspect may be a Rails holdover. 

Controller Test File:

```ruby
MyApp.controllers :test do
  get :index do
    "Welcome to the Testing Controller"
  end

  get :raise do
    "/test/raise"
  end

  get :activerecord_error do
    "/test/activerecord_error"
  end

  get :test_with_alias, :map => '/alternate_test/aliased' do
    "/alternative_test/aliased"
  end
end
```
Here's the logger used, which is just `logger.info payload[:action]` inside the ensure of the padrino integration file:

```
   INFO - MyApp:test#/test
  DEBUG -      GET (71.3915ms) /test - 200 OK
   INFO - MyApp:test#/test/raise
  DEBUG -      GET (0.1684ms) /test/raise - 200 OK
   INFO - MyApp:test#/test/activerecord_error
  DEBUG -      GET (0.1632ms) /test/activerecord_error - 200 OK
   INFO - MyApp:test#/alternate_test/aliased
  DEBUG -      GET (0.1807ms) /alternate_test/aliased - 200 OK
```