### PR TITLE
Support ActiveJob wrapped jobs

### DIFF
--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -15,7 +15,7 @@ if defined?(::Sidekiq)
         def call(worker, item, queue)
           Appsignal.monitor_transaction(
             'perform_job.sidekiq',
-            :class       => item['class'],
+            :class       => item['wrapped'] || item['class'],
             :method      => 'perform',
             :metadata    => formatted_metadata(item),
             :params      => format_args(item['args']),

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -47,6 +47,23 @@ describe "Sidekiq integration" do
       )
     end
 
+    it "reports the correct job class for a ActiveJob wrapped job" do
+      item['wrapped'] = 'ActiveJobClass'
+      Appsignal.should_receive(:monitor_transaction).with(
+        'perform_job.sidekiq',
+        :class    => 'ActiveJobClass',
+        :method   => 'perform',
+        :metadata => {
+          'retry_count' => "0",
+          'queue'       => 'default',
+          'extra'       => 'data',
+          'wrapped'     => 'ActiveJobClass'
+        },
+        :params      => ['Model', "1"],
+        :queue_start => Time.parse('01-01-2001 10:00:00UTC')
+      )
+    end
+
     after do
       Timecop.freeze(Time.parse('01-01-2001 10:01:00UTC')) do
         Appsignal::Integrations::SidekiqPlugin.new.call(worker, item, queue) do


### PR DESCRIPTION
ActiveJob uses a single worker class (`ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper`)
to run all the enqueued jobs, but it exposes the job name as `wrapped` entry and
we can use it to report the underlying job class to AppSignal.

This is a similar approach taken used to display AJ jobs on the the Sidekiq UI
mperham/sidekiq#2259