### PR TITLE
Route `add_exception` through Appsignal instead of setting it on the …

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -30,7 +30,7 @@ module Appsignal
       ensure
         # In production newer versions of Sinatra don't raise errors, but store
         # them in the sinatra.error env var.
-        Appsignal::Transaction.current.add_exception(env['sinatra.error']) if env['sinatra.error']
+        Appsignal.add_exception(env['sinatra.error']) if env['sinatra.error']
       end
 
       def raw_payload(env)

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -85,7 +85,7 @@ if defined?(::Sinatra)
         transaction = double
         transaction.stub(:set_process_action_event)
         transaction.stub(:add_event)
-        transaction.should_receive(:add_exception).with(exception)
+        Appsignal.should_receive(:add_exception).with(exception)
         Appsignal::Transaction.stub(:current => transaction)
 
         middleware.call_with_appsignal_monitoring(env)


### PR DESCRIPTION
…transaction directly. This way the active check and the ignored_exception check is done.