### PR TITLE
Stopping in worker processes

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -18,6 +18,7 @@ module Appsignal
       require 'appsignal/integrations/sidekiq'
       require 'appsignal/integrations/resque'
       require 'appsignal/integrations/sequel'
+      require 'appsignal/integrations/unicorn'
     end
 
     def load_instrumentations

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -16,6 +16,7 @@ module Appsignal
       require 'appsignal/integrations/celluloid'
       require 'appsignal/integrations/delayed_job'
       require 'appsignal/integrations/passenger'
+      require 'appsignal/integrations/puma'
       require 'appsignal/integrations/sidekiq'
       require 'appsignal/integrations/resque'
       require 'appsignal/integrations/sequel'

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -15,6 +15,7 @@ module Appsignal
     def load_integrations
       require 'appsignal/integrations/celluloid'
       require 'appsignal/integrations/delayed_job'
+      require 'appsignal/integrations/passenger'
       require 'appsignal/integrations/sidekiq'
       require 'appsignal/integrations/resque'
       require 'appsignal/integrations/sequel'

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -73,13 +73,14 @@ module Appsignal
       Appsignal::Extension.stop
     end
 
+    # Wrap a transaction with appsignal monitoring.
     def monitor_transaction(name, env={})
       unless active?
         yield
         return
       end
 
-       if name.start_with?('perform_job'.freeze)
+      if name.start_with?('perform_job'.freeze)
         namespace = Appsignal::Transaction::BACKGROUND_JOB
         request   = Appsignal::Transaction::GenericRequest.new(env)
       elsif name.start_with?('process_action'.freeze)
@@ -105,6 +106,17 @@ module Appsignal
         transaction.set_http_or_background_queue_start
         Appsignal::Transaction.complete_current!
       end
+    end
+
+    # Monitor a transaction, stop Appsignal and wait for this single transaction to be
+    # flushed.
+    #
+    # Useful for cases such as Rake tasks and Resque-like systems where a process is
+    # forked and immediately exits after the transaction finishes.
+    def monitor_single_transaction(name, env={}, &block)
+      monitor_transaction(name, env, &block)
+    ensure
+      stop
     end
 
     def listen_for_error(&block)

--- a/lib/appsignal/integrations/celluloid.rb
+++ b/lib/appsignal/integrations/celluloid.rb
@@ -4,6 +4,7 @@ if defined?(::Celluloid)
   # Some versions of Celluloid have race conditions while exiting
   # that can result in a dead lock. We stop appsignal before shutting
   # down Celluloid so we're sure our thread does not aggravate this situation.
+  # This way we also make sure any outstanding transactions get flushed.
 
   ::Celluloid.class_eval do
     class << self

--- a/lib/appsignal/integrations/delayed_job.rb
+++ b/lib/appsignal/integrations/delayed_job.rb
@@ -8,6 +8,10 @@ if defined?(::Delayed::Plugin)
           lifecycle.around(:invoke_job) do |job, &block|
             invoke_with_instrumentation(job, block)
           end
+
+          lifecycle.after(:loop) do |loop|
+            Appsignal.stop
+          end
         end
 
         def self.invoke_with_instrumentation(job, block)

--- a/lib/appsignal/integrations/passenger.rb
+++ b/lib/appsignal/integrations/passenger.rb
@@ -1,0 +1,7 @@
+if defined?(::PhusionPassenger)
+  Appsignal.logger.info('Loading Passenger integration')
+
+  ::PhusionPassenger.on_event(:stopping_worker_process) do
+    Appsignal.stop
+  end
+end

--- a/lib/appsignal/integrations/puma.rb
+++ b/lib/appsignal/integrations/puma.rb
@@ -1,0 +1,9 @@
+if defined?(::Puma)
+  Appsignal.logger.info('Loading Puma integration')
+
+  if ::Puma.cli_config
+    ::Puma.cli_config.options[:before_worker_shutdown] << Proc.new do |id|
+      Appsignal.stop
+    end
+  end
+end

--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -23,7 +23,7 @@ module Rake
       transaction.set_action(name)
       transaction.set_error(error)
       transaction.complete!
-      sleep 0.5 # Give us some time to flush to the agent
+      Appsignal.stop
       raise error
     end
   end

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -5,7 +5,7 @@ if defined?(::Resque)
     module Integrations
       module ResquePlugin
         def around_perform_resque_plugin(*args)
-          Appsignal.monitor_transaction(
+          Appsignal.monitor_single_transaction(
             'perform_job.resque',
             :class => self.to_s,
             :method => 'perform'

--- a/lib/appsignal/integrations/unicorn.rb
+++ b/lib/appsignal/integrations/unicorn.rb
@@ -1,0 +1,18 @@
+if defined?(::Unicorn)
+  Appsignal.logger.info('Loading Unicorn integration')
+
+  # Make sure the last transaction in a worker gets flushed.
+  #
+  # We'd love to be able to hook this into Unicorn in a less
+  # intrusive way, but this is the best we can do given the
+  # options we have.
+
+  class Unicorn::Worker
+    alias_method :original_close, :close
+
+    def close
+      Appsignal.stop
+      original_close
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/passenger_spec.rb
+++ b/spec/lib/appsignal/integrations/passenger_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "Passenger integration" do
+  let(:file) { File.expand_path('lib/appsignal/integrations/passenger.rb') }
+  before(:all) do
+    module PhusionPassenger
+    end
+  end
+
+  it "adds behavior to stopping_worker_process" do
+    PhusionPassenger.should_receive(:on_event).with(:stopping_worker_process)
+    load file
+  end
+
+  context "without passenger" do
+    before(:all) { Object.send(:remove_const, :PhusionPassenger) }
+
+    specify { expect { PhusionPassenger }.to raise_error(NameError) }
+    specify { expect { load file }.to_not raise_error }
+  end
+end

--- a/spec/lib/appsignal/integrations/puma_spec.rb
+++ b/spec/lib/appsignal/integrations/puma_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "Puma integration" do
+  let(:file) { File.expand_path('lib/appsignal/integrations/puma.rb') }
+  before(:all) do
+    class Puma
+      def self.cli_config
+        @cli_config ||= CliConfig.new
+      end
+    end
+
+    class CliConfig
+      attr_accessor :options
+
+      def initialize
+        @options = {}
+        @options[:before_worker_shutdown] = []
+      end
+    end
+  end
+  before do
+    load file
+    start_agent
+  end
+
+  it "should add a before shutdown worker callback" do
+    Puma.cli_config.options[:before_worker_shutdown].first.should be_a(Proc)
+  end
+
+  context "without Puma" do
+    before(:all) { Object.send(:remove_const, :Puma) }
+
+    specify { expect { Puma }.to raise_error(NameError) }
+    specify { expect { load file }.to_not raise_error }
+  end
+end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -39,7 +39,7 @@ describe "Resque integration" do
         end
 
         it "should wrap in a transaction with the correct params" do
-          Appsignal.should_receive(:monitor_transaction).with(
+          Appsignal.should_receive(:monitor_single_transaction).with(
             'perform_job.resque',
             :class => 'Resque::Job',
             :method => 'perform'

--- a/spec/lib/appsignal/integrations/unicorn_spec.rb
+++ b/spec/lib/appsignal/integrations/unicorn_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "Unicorn integration" do
+  let(:file) { File.expand_path('lib/appsignal/integrations/unicorn.rb') }
+  before(:all) do
+    module Unicorn
+      class Worker
+        def close
+        end
+      end
+    end
+  end
+  before do
+    load file
+    start_agent
+  end
+
+  it "should add behavior to Unicorn::Worker#close" do
+    worker = Unicorn::Worker.new
+
+    Appsignal.should_receive(:stop)
+    worker.should_receive(:original_close)
+
+    worker.close
+  end
+
+  context "without unicorn" do
+    before(:all) { Object.send(:remove_const, :Unicorn) }
+
+    specify { expect { Unicorn }.to raise_error(NameError) }
+    specify { expect { load file }.to_not raise_error }
+  end
+end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -300,6 +300,40 @@ describe Appsignal do
       end
     end
 
+    describe ".monitor_single_transaction" do
+      context "with a successful call" do
+        it "should call monitor_transaction and stop" do
+          Appsignal.should_receive(:monitor_transaction).with(
+            'perform_job.something',
+            :key => :value
+          ).and_yield
+          Appsignal.should_receive(:stop)
+
+          Appsignal.monitor_single_transaction('perform_job.something', :key => :value) do
+            # nothing
+          end
+        end
+      end
+
+      context "with an erroring call" do
+        let(:error) { VerySpecificError.new('the roof') }
+
+        it "should call monitor_transaction and stop and then raise the error" do
+          Appsignal.should_receive(:monitor_transaction).with(
+            'perform_job.something',
+            :key => :value
+          ).and_yield
+          Appsignal.should_receive(:stop)
+
+          lambda {
+            Appsignal.monitor_single_transaction('perform_job.something', :key => :value) do
+              raise error
+            end
+          }.should raise_error(error)
+        end
+      end
+    end
+
     describe ".tag_request" do
       before { Appsignal::Transaction.stub(:current => transaction) }
 


### PR DESCRIPTION
Call `Appsignal.stop` in the right location for various tools we support.