### PR TITLE
Fix for trying to create Rack request for wrong env

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -106,7 +106,7 @@ module Appsignal
         logger.error('Can\'t send exception, given value is not an exception')
         return
       end
-      transaction = Appsignal::Transaction.create(SecureRandom.uuid, ENV)
+      transaction = Appsignal::Transaction.create(SecureRandom.uuid, nil)
       transaction.add_exception(exception)
       transaction.set_tags(tags) if tags
       transaction.complete!

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -60,7 +60,7 @@ module Appsignal
     end
 
     def request
-      ::Rack::Request.new(@env)
+      ::Rack::Request.new(@env) if @env
     end
 
     def set_tags(given_tags={})
@@ -244,6 +244,7 @@ module Appsignal
     end
 
     def sanitize_session_data!
+      return unless request
       @sanitized_session_data = Appsignal::ParamsSanitizer.sanitize(
         request.session.to_hash
       ) if Appsignal.config[:skip_session_data] == false

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -77,6 +77,12 @@ describe Appsignal::Transaction do
       subject { transaction.request }
 
       it { should be_a ::Rack::Request }
+
+      context "without env" do
+        let(:env) { nil }
+
+        it { should be_nil }
+      end
     end
 
     describe '#set_process_action_event' do
@@ -730,6 +736,18 @@ describe Appsignal::Transaction do
       context "when skipping session data" do
         before do
           Appsignal.config = {:skip_session_data => true}
+        end
+
+        it "does not pass the session data into the params sanitizer" do
+          Appsignal::ParamsSanitizer.should_not_receive(:sanitize)
+          subject
+          transaction.sanitized_session_data.should == {}
+        end
+      end
+
+      context "without a request" do
+        before do
+          transaction.stub(:request => nil)
         end
 
         it "does not pass the session data into the params sanitizer" do


### PR DESCRIPTION
When using `send_exception` we passed in the env, which can sometimes be incorrect input for a Rack request. Fix this by not using the env at all.