### PR TITLE
Do not process `env['sinatra.errors']`.

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -34,9 +34,6 @@ module Appsignal
           transaction.set_error(error)
           raise error
         ensure
-          # In production newer versions of Sinatra don't raise errors, but store
-          # them in the sinatra.error env var.
-          transaction.set_error(env['sinatra.error']) if env['sinatra.error']
           transaction.set_action(env['sinatra.route'])
           transaction.set_metadata('path', request.path)
           transaction.set_metadata('method', request.request_method)


### PR DESCRIPTION
See https://github.com/appsignal/appsignal/issues/97