### PR TITLE
Fix #99: Transaction never completes if setup of streaming response fails

### DIFF
--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -88,10 +88,11 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     context "with an exception in the instrumentation call" do
-      it "should add the exception to the transaction" do
+      it "should add the exception to the transaction and complete it" do
         allow( app ).to receive(:call).and_raise(VerySpecificError.new('broken'))
 
         expect( transaction ).to receive(:set_error)
+        expect( Appsignal::Transaction ).to receive(:complete_current!)
 
         listener.call_with_appsignal_monitoring(env) rescue VerySpecificError
       end


### PR DESCRIPTION
See #99 