### PR TITLE
Let params sanitizer keep unmodified nil, true and false

### DIFF
--- a/lib/appsignal/params_sanitizer.rb
+++ b/lib/appsignal/params_sanitizer.rb
@@ -25,10 +25,8 @@ module Appsignal
           sanitize_hash(value)
         when Array
           sanitize_array(value)
-        when Fixnum, String, Symbol, Float
+        when TrueClass, FalseClass, NilClass, Fixnum, String, Symbol, Float
           unmodified(value)
-        when TrueClass, FalseClass
-          stringified(value)
         else
           inspected(value)
         end
@@ -46,10 +44,6 @@ module Appsignal
           target_array[index] = sanitize_value(item)
         end
         target_array
-      end
-
-      def stringified(value)
-        value.to_s
       end
 
       def unmodified(value)

--- a/spec/lib/appsignal/params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/params_sanitizer_spec.rb
@@ -22,6 +22,7 @@ describe Appsignal::ParamsSanitizer do
       :float      => 0.0,
       :bool_true  => true,
       :bool_false => false,
+      :nil        => nil,
       :int        => 1,
       :hash       => {
         :nested_text  => 'string',
@@ -52,8 +53,9 @@ describe Appsignal::ParamsSanitizer do
     its([:file])        { should include '::UploadedFile' }
     its([:float])       { should == 0.0 }
     its([:int])         { should == 1 }
-    its([:bool_true])   { should == 'true' }
-    its([:bool_false])  { should == 'false' }
+    its([:bool_true])   { should == true }
+    its([:bool_false])  { should == false }
+    its([:nil])         { should == nil }
 
     context "hash" do
       subject { params[:hash] }


### PR DESCRIPTION
Brings the behavior in line with the sanitizer in utils.